### PR TITLE
feat: load nav categories from /api/categories

### DIFF
--- a/app/components/layout/HeaderNavigation.vue
+++ b/app/components/layout/HeaderNavigation.vue
@@ -14,16 +14,16 @@
 
         <NuxtLink
         v-for="cat in categories || []"
-        :key="cat"
-        :to="`/category/${cat}`"
+        :key="cat.slug"
+        :to="`/category/${cat.slug}`"
         :class="[
             'text-sm px-2 py-1 rounded transition',
-            activeCategory === cat
+            activeCategory === cat.slug
             ? 'bg-[#F97316] text-white'
             : 'text-[#111827] hover:text-[#F97316]'
         ]"
         >
-        {{ cat }}
+        {{ cat.name }}
         </NuxtLink>
     </div>
 </template>

--- a/app/composables/useCategories.ts
+++ b/app/composables/useCategories.ts
@@ -1,18 +1,13 @@
-import type { Product } from '~/types/product'
+import type { Category } from '~/types/category'
 
 export const useCategories = () => {
-  return useAsyncData<string[]>(
+  return useAsyncData<Category[]>(
     'categories',
-    async () => {
-      const products = await $fetch<Product[]>('/api/products')
-      const categories = products
-        .map((product) => String(product.category).trim())
-        .filter(Boolean)
-
-      return [...new Set(categories)]
-    },
+    () => $fetch<Category[]>('/api/categories'),
     {
-      default: () => []
+      default: () => [],
+      server: true,
+      lazy: false
     }
   )
 } 

--- a/server/api/categories.get.ts
+++ b/server/api/categories.get.ts
@@ -1,0 +1,23 @@
+import { fetchDirectusCategories } from '../utils/directusCategories'
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const fromDirectus = await fetchDirectusCategories(config.directusUrl)
+  if (fromDirectus.length > 0) return fromDirectus
+
+  // Public role may read products but not the categories collection.
+  const products = await $fetch<Array<{ category: string }>>('/api/products', {
+    baseURL: getRequestURL(event).origin
+  })
+
+  const slugs = [...new Set(
+    products
+      .map((product) => String(product.category ?? '').trim())
+      .filter(Boolean)
+  )].sort()
+
+  return slugs.map((slug) => ({
+    slug,
+    name: slug
+  }))
+})

--- a/server/api/products.get.ts
+++ b/server/api/products.get.ts
@@ -1,3 +1,5 @@
+import { fetchDirectusCategoryMap } from '../utils/directusCategories'
+
 type DirectusProduct = {
   id: number;
   name: string;
@@ -17,16 +19,6 @@ type DirectusResponse = {
   data: DirectusProduct[];
 };
 
-type DirectusCategory = {
-  id: number | string;
-  slug?: string;
-  name?: string;
-};
-
-type DirectusCategoryResponse = {
-  data: DirectusCategory[];
-};
-
 const FALLBACK_CATEGORY_LABELS: Record<string, string> = {
   '1': 'fragrances',
   '2': 'beauty',
@@ -37,20 +29,7 @@ export default defineEventHandler(async () => {
   const config = useRuntimeConfig();
   const apiBase = config.directusUrl;
   const fields = 'id,name,price,main_image,category.id,category.slug,category.name';
-  const categoryMap = new Map<string, string>();
-
-  try {
-    const categoriesResponse = await $fetch<DirectusCategoryResponse>(
-      `${apiBase}/items/categories?fields=id,slug,name`
-    );
-    for (const category of categoriesResponse?.data || []) {
-      const key = String(category.id);
-      const value = category.slug || category.name;
-      if (value) categoryMap.set(key, value);
-    }
-  } catch {
-    // Ignore category-map failures; product list should still load.
-  }
+  const categoryMap = await fetchDirectusCategoryMap(apiBase);
 
   let result: DirectusResponse;
   try {

--- a/server/api/products/[id].get.ts
+++ b/server/api/products/[id].get.ts
@@ -1,3 +1,5 @@
+import { fetchDirectusCategoryMap } from '../../utils/directusCategories'
+
 type DirectusProduct = {
   id: number;
   name: string;
@@ -18,16 +20,6 @@ type DirectusSingleResponse = {
   data: DirectusProduct;
 };
 
-type DirectusCategory = {
-  id: number | string;
-  slug?: string;
-  name?: string;
-};
-
-type DirectusCategoryResponse = {
-  data: DirectusCategory[];
-};
-
 const FALLBACK_CATEGORY_LABELS: Record<string, string> = {
   '1': 'fragrances',
   '2': 'beauty',
@@ -39,20 +31,7 @@ export default defineEventHandler(async (event) => {
   const apiBase = config.directusUrl;
   const id = getRouterParam(event, 'id');
   const fields = 'id,name,description,price,main_image,category.id,category.slug,category.name';
-  const categoryMap = new Map<string, string>();
-
-  try {
-    const categoriesResponse = await $fetch<DirectusCategoryResponse>(
-      `${apiBase}/items/categories?fields=id,slug,name`
-    );
-    for (const category of categoriesResponse?.data || []) {
-      const key = String(category.id);
-      const value = category.slug || category.name;
-      if (value) categoryMap.set(key, value);
-    }
-  } catch {
-    // Ignore category-map failures; product details should still load.
-  }
+  const categoryMap = await fetchDirectusCategoryMap(apiBase);
 
   if (!id) {
     throw createError({

--- a/server/utils/directusCategories.ts
+++ b/server/utils/directusCategories.ts
@@ -1,0 +1,52 @@
+type DirectusCategory = {
+  id: number | string
+  slug?: string
+  name?: string
+}
+
+type DirectusCategoryResponse = {
+  data: DirectusCategory[]
+}
+
+export type CategoryDto = {
+  name: string
+  slug: string
+}
+
+export async function fetchDirectusCategoryMap(apiBase: string): Promise<Map<string, string>> {
+  const categoryMap = new Map<string, string>()
+
+  try {
+    const response = await $fetch<DirectusCategoryResponse>(
+      `${apiBase}/items/product_category?fields=id,slug,name`
+    )
+    for (const category of response?.data || []) {
+      const key = String(category.id)
+      const value = category.slug || category.name
+      if (value) categoryMap.set(key, value)
+    }
+  } catch {
+    // Product routes should still work if categories cannot be loaded.
+  }
+
+  return categoryMap
+}
+
+export async function fetchDirectusCategories(apiBase: string): Promise<CategoryDto[]> {
+  try {
+    const response = await $fetch<DirectusCategoryResponse>(
+      `${apiBase}/items/product_category?fields=id,slug,name`
+    )
+
+    return (response?.data || [])
+      .map((category) => {
+        const slug = category.slug || category.name
+        const name = category.name || category.slug
+        if (!slug || !name) return null
+        return { name, slug }
+      })
+      .filter((category): category is CategoryDto => category !== null)
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
* New `GET /api/categories` endpoint
* Shared `directusCategories` utility
* `useCategories` now uses `/api/categories`
* `HeaderNavigation` updated with slug / name support
* Fallback to product categories when Directus categories are empty
